### PR TITLE
Add context to all requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -236,12 +236,7 @@ func newBulkPostRequestWithContext(ctx context.Context, urlStr, apiKey string, i
 	}
 
 	if err := ctx.Err(); err != nil {
-		switch err {
-		case context.DeadlineExceeded:
-			return nil, errors.New("context timeout exceeded")
-		case context.Canceled:
-			return nil, errors.New("context cancelled")
-		}
+		return nil, err
 	}
 
 	buf := &bytes.Buffer{}

--- a/client.go
+++ b/client.go
@@ -149,11 +149,6 @@ func (c Client) LookupWithContext(ctx context.Context, ip string) (IP, error) {
 	return pip, nil
 }
 
-func newGetRequest(urlStr, apiKey string) (*http.Request, error) {
-	ctx := context.Background()
-	return newGetRequestWithContext(ctx, urlStr, apiKey)
-}
-
 func newGetRequestWithContext(ctx context.Context, urlStr, apiKey string) (*http.Request, error) {
 	if len(urlStr) == 0 {
 		return nil, errors.New("url cannot be an empty string")
@@ -216,10 +211,6 @@ func (c *Client) RawBulkLookup(ips []string) (*http.Response, error) {
 
 		return nil, newError(a.Message, resp.StatusCode)
 	}
-}
-
-func newBulkPostRequest(urlStr, apiKey string, ips []string) (*http.Request, error) {
-	return newBulkPostRequestWithContext(context.Background(), urlStr, apiKey, ips)
 }
 
 func newBulkPostRequestWithContext(ctx context.Context, urlStr, apiKey string, ips []string) (*http.Request, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@
 package ipdata
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -583,7 +584,7 @@ func mustParseURL(u string) *url.URL {
 	return v
 }
 
-func Test_newGetRequest(t *testing.T) {
+func Test_newGetRequestWithContext(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
@@ -607,8 +608,8 @@ func Test_newGetRequest(t *testing.T) {
 			url:  "http://localhost/",
 			want: &http.Request{
 				Header: map[string][]string{
-					"User-Agent": []string{userAgent},
-					"Accept":     []string{"application/json"},
+					"User-Agent": {userAgent},
+					"Accept":     {"application/json"},
 				},
 				URL: mustParseURL("http://localhost/?api-key=abc123"),
 			},
@@ -617,8 +618,8 @@ func Test_newGetRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newGetRequest(tt.url, tt.key)
-			if cont := testErrCheck(t, "newGetRequest()", tt.err, err); !cont {
+			got, err := newGetRequestWithContext(context.Background(), tt.url, tt.key)
+			if cont := testErrCheck(t, "newGetRequestWithContext()", tt.err, err); !cont {
 				return
 			}
 
@@ -637,7 +638,7 @@ func Test_newGetRequest(t *testing.T) {
 	}
 }
 
-func Test_newBulkPostRequest(t *testing.T) {
+func Test_newBulkPostRequestWithContext(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
@@ -669,9 +670,9 @@ func Test_newBulkPostRequest(t *testing.T) {
 			ips:  []string{"8.8.8.8", "8.8.4.4"},
 			want: &http.Request{
 				Header: map[string][]string{
-					"User-Agent":   []string{userAgent},
-					"Accept":       []string{"application/json"},
-					"Content-Type": []string{"application/json"},
+					"User-Agent":   {userAgent},
+					"Accept":       {"application/json"},
+					"Content-Type": {"application/json"},
 				},
 				URL: mustParseURL("http://localhost/?api-key=abc123"),
 			},
@@ -680,8 +681,8 @@ func Test_newBulkPostRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newBulkPostRequest(tt.url, tt.key, tt.ips)
-			if cont := testErrCheck(t, "newBulkPostRequest()", tt.err, err); !cont {
+			got, err := newBulkPostRequestWithContext(context.Background(), tt.url, tt.key, tt.ips)
+			if cont := testErrCheck(t, "newBulkPostRequestWithContext()", tt.err, err); !cont {
 				return
 			}
 


### PR DESCRIPTION
This adds the possibility to provide a `context.Context` to all GET
and POST requests and introduces:

- `LookupWithContext` calls `RawLookupWithContext` calls `newGetRequestWithContext`
- `BulkLookupWithContext` calls `RawBulkLookupWithContext` calls `newPostRequestWithContext`

The new functions are duplicated from the old ones but use a `NewRequestWithContext` instead.
The old functions call the `WithContext` functions but provide a `context.Background()`, so
only one set needs to be maintained.

Closes #14 